### PR TITLE
refactor: remove unused private fields

### DIFF
--- a/java-example/src/main/java/com/caphyon/codegold/structures/Vehicle.java
+++ b/java-example/src/main/java/com/caphyon/codegold/structures/Vehicle.java
@@ -3,16 +3,9 @@ package com.caphyon.codegold.structures;
 public class Vehicle {
     private String make;
     private String model;
+    private int f_year; 
 
-//    Example of bad practices
-    private int yearwhenthecarwasmade;
-    private int fyear;
-    private int f_year; // Year when the car was made
-    private int f_y;
-
-//    Example of good practices
     private int fabricationYear;
-    private int year;
 
     private String engine_type;
     private float engineCapacity;


### PR DESCRIPTION
A private field which is not referenced anywhere in this file was detected.

Such a field is useless and can be safely removed.